### PR TITLE
add `onlyTimerAggregates` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Add a structure to your configuration called "elasticsearch":
 	 timerType:     "timer",
 	 timerDataType: "timer_data",
 	 gaugeDataType: "gauge",
-     formatter:     "default_format"
+         onlyTimerAggregates: false, // whether to store each timer value (default) or only aggregates for the configured flush interval
+         formatter:     "default_format"
  }
 ```
 
@@ -65,6 +66,8 @@ Nginx config proxy example:
 The field _indexPrefix_ is used as the prefix for your dynamic indices: for example "statsd-2014.02.04"
 
 The field _indexTimestamp_ allows you to determine the timestamping for your dynamic index. "year", "month" and "day" would produce "statsd-2014", "statsd-2014.02", "statsd-2014.02.04" respectively.
+
+Using the boolean field _onlyTimerAggregates_ (default to `false`), you may configure to store only aggregates of a certain timer (one single document), instead of having one document per received timer value. This can be helpful in scenarios of high-frequent timers adding preasure to the ES backend. When accuracy of the configured flush interval is "fair enough", you can save a lot of inserts. Note this only works if there a aggregates for your timers created by StatsD at all (see [config.histogram](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#timing)).
 
 NOTE: You can also set the configuratons using environment variables, eg. `ES_HOST`, `ES_PATH`, `ES_PORT`, `ES_INDEX_TIMESTAMP`, `ES_TIME_DATATYPE`
 

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -35,6 +35,7 @@ let elasticUsername;
 let elasticPassword;
 let elasticHttps;
 let elasticCertCa;
+let onlyTimerAggregates;
 
 let elasticStats = {};
 
@@ -83,7 +84,9 @@ function insert(listCounters, listTimers, listTimerData, listGaugeData) {
     }
 
     let payload = transform(listCounters, statsdIndex, elasticCountType);
-    payload = payload.concat(transform(listTimers, statsdIndex, elasticTimerType));
+    if (!onlyTimerAggregates) {
+      payload = payload.concat(transform(listTimers, statsdIndex, elasticTimerType));
+    }
     payload = payload.concat(transform(listTimerData, statsdIndex, elasticTimerType));
     payload = payload.concat(transform(listGaugeData, statsdIndex, elasticGaugeDataType));
 
@@ -155,14 +158,14 @@ const flush_stats = function elastic_flush(ts, metrics) {
     numStats += fm.counters(key, metrics.counters[key], ts, array_counts);
   }
 
-  for (key in metrics.timers) {
-    numStats += fm.timers(key, metrics.timers[key], ts, array_timers);
+  if (!onlyTimerAggregates) {
+    for (key in metrics.timers) {
+      numStats += fm.timers(key, metrics.timers[key], ts, array_timers);
+    }
   }
 
-  if (array_timers.length > 0) {
-    for (key in metrics.timer_data) {
-      fm.timer_data(key, metrics.timer_data[key], ts, array_timer_data);
-    }
+  for (key in metrics.timer_data) {
+    fm.timer_data(key, metrics.timer_data[key], ts, array_timer_data);
   }
 
   for (key in metrics.gauges) {
@@ -208,6 +211,7 @@ exports.init = function (startup_time, config, events, logger) {
     elasticPassword = configEs.password || process.env.ES_PASSWORD || undefined;
     elasticHttps = configEs.secure || process.env.ES_SECURE || false;
     elasticCertCa = configEs.ca || undefined;
+    onlyTimerAggregates = configEs.onlyTimerAggregates || false;
 
     fm = require('./' + elasticFormatter + '.js');
     if (debug) {


### PR DESCRIPTION
In a scenario with high-frequent timer values arriving at StatsD, you can configure to only store aggregated values (aka "histogram" / timer_stats) to the Elasticsearch backend. This could save many insert operations when the accuracy of the configured flush interval is "fair enough" for your measurement.